### PR TITLE
remove extra link info from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## React Native Background Color
-  This module alows you to set the root backgound color of your react-native app from JS. Supports only Android at the moment.
+  This module alows you to set the root backgound color of your react-native app from JS.
+
+**Supports only Android at the moment.**
 
 ### Installation
 
@@ -15,38 +17,11 @@ $ npm install --save react-native-background-color
 $ yarn add react-native-background-color
 ```
 
-#### Link module in Android
+#### Link module
 
-   * Add the following to `android/settings.gradle`:
-        ```
-        include ':react-native-background-color'
-        project(':react-native-background-color').projectDir = new File(settingsDir, '../node_modules/react-native-background-color/android')
-        ```
-
-    * Add the following to `android/app/build.gradle`:
-        ```xml
-        ...
-
-        dependencies {
-            ...
-            compile project(':react-native-background-color')
-        }
-        ```
-    * Add the following to `android/app/src/main/java/**/MainApplication.java`:
-        ```java
-        import io.rado.backgroundcolor.BackgroundColor;  // add this for react-native-background-color
-
-        public class MainApplication extends Application implements ReactApplication {
-
-            @Override
-            protected List<ReactPackage> getPackages() {
-                return Arrays.<ReactPackage>asList(
-                    new MainReactPackage(),
-                    new BackgroundColor()     // add this for react-native-background-color
-                );
-            }
-        }
-        ```
+```sh
+$ react-native link
+```
 
 ### Usage
 


### PR DESCRIPTION
Hi there,

I tried setting up with your instructions but they seemed out of date as a few things have changed like
`import io.rado.backgroundcolor.BackgroundColor;`
to 
`import io.rado.backgroundcolor.BackgroundColorPackage;`

I also noticed that theres no need manually copy all of link code as calling `react-native link `takes care of that.

This PR updates the readme with the correct link instructions.
Thanks for creating this tool !