### PR TITLE
Solved: version issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,16 +17,20 @@ buildscript {
     }
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet("compileSdkVersion", 23)
+    buildToolsVersion safeExtGet("buildToolsVersion","23.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
         versionCode 1
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         // get version name from package.json version
         versionName computeVersionName()
     }
@@ -40,5 +44,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
when i was trying to using your library i had two errors.

``` error
INFO: The specified Android SDK Build Tools version (23.0.1) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.4.1.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '23.0.1'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
```
``` error
INFO: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
```

so, I changed few lines to give u suggestion.