### PR TITLE
fix - error in build on typescript

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,8 +24,8 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 23)
-    buildToolsVersion safeExtGet("buildToolsVersion","23.0.1")
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
+    buildToolsVersion safeExtGet("buildToolsVersion","28.0.1")
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
> Task :react-native-background-color:verifyReleaseResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-background-color:verifyReleaseResources'.
> 1 exception was raised by workers:
  com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
  /home/ilegra/Documentos/orsegups/fork/installation-app/InstallationApp/node_modules/react-native-background-color/android/build/intermediates/res/merged/release/values-v28/values-v28.xml:7: error: resource android:attr/dialogCornerRadius not found.
  /home/ilegra/Documentos/orsegups/fork/installation-app/InstallationApp/node_modules/react-native-background-color/android/build/intermediates/res/merged/release/values-v28/values-v28.xml:11: error: resource android:attr/dialogCornerRadius not found.
  /home/ilegra/Documentos/orsegups/fork/installation-app/InstallationApp/node_modules/react-native-background-color/android/build/intermediates/res/merged/release/values/values.xml:2737: error: resource android:attr/fontVariationSettings not found.
  /home/ilegra/Documentos/orsegups/fork/installation-app/InstallationApp/node_modules/react-native-background-color/android/build/intermediates/res/merged/release/values/values.xml:2738: error: resource android:attr/ttcIndex not found.
  error: failed linking references.
  

**** Solved changed the version.